### PR TITLE
Fix auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gude-tunes",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "homepage": "http://DanTheManGude.github.io/gude-tunes",
   "private": true,
   "dependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -10,11 +10,12 @@ import {
 import { messageTypes, buttonProperties, existingUsersMap } from "./Constants";
 
 function App() {
-  const {
-    code,
-    message,
-    hashItems: { access_token },
-  } = calculateAuthentication();
+  const [authState, setAuthState] = useState({
+    code: 0,
+    message: "",
+    accessToken: null,
+  });
+  const { code, message, accessToken } = authState;
 
   const [messageList, setMessageList] = useState([]);
   const [user, setUser] = useState();
@@ -27,6 +28,23 @@ function App() {
   };
 
   useEffect(() => {
+    let isMounted = true;
+
+    const initializeAuth = async () => {
+      const authentication = await calculateAuthentication();
+      if (isMounted) {
+        setAuthState(authentication);
+      }
+    };
+
+    initializeAuth();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
     const startingMessage =
       code === -1
         ? {
@@ -34,24 +52,23 @@ function App() {
             text: message,
           }
         : code === 1
-        ? {
-            type: messageTypes.SUCCESS,
-            text: "Login succesfull!",
-          }
-        : {
-            type: messageTypes.INFO,
-            source: "Welcome",
-            text: "Please login below to use the app.",
-          };
+          ? {
+              type: messageTypes.SUCCESS,
+              text: "Login succesfull!",
+            }
+          : {
+              type: messageTypes.INFO,
+              source: "Welcome",
+              text: "Please login below to use the app.",
+            };
 
     addNewMessage(startingMessage);
   }, [code, message]);
 
   useEffect(() => {
-    if (!access_token) return;
+    if (!accessToken) return;
 
-    console.log(access_token);
-    makeRequest("me", "GET", access_token)
+    makeRequest("me", "GET", accessToken)
       .then((r) => {
         if (r.status === 401) {
           window.location.href = `${window.location.origin}${window.location.pathname}`;
@@ -68,7 +85,7 @@ function App() {
               source: "Application",
               text: `Sorry ${displayName}, Only designated Spotify accounts can use the application. Click below to request access.`,
             },
-            12000
+            12000,
           );
         }
         setUser({ isNew, info: { email, displayName } });
@@ -81,7 +98,7 @@ function App() {
         });
         console.error(error);
       });
-  }, [access_token]);
+  }, [accessToken]);
 
   const renderMessageList = () => {
     return (
@@ -133,9 +150,9 @@ function App() {
             className={["utility-btn", ...classNames].join(" ")}
             onClick={getButtonOnClick(
               buttonId,
-              access_token,
+              accessToken,
               addNewMessage,
-              existingUsersMap[user.info.email]
+              existingUsersMap[user.info.email],
             )}
           >
             {text}

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -7,8 +7,76 @@ import {
   buttonProperties,
 } from "./Constants";
 
-export const calculateAuthentication = () => {
-  const authentication = { code: null, hashItems: {}, message: "" };
+const SPOTIFY_CLIENT_ID = "125aeb2f61c242c68fe33802c481bb08";
+const SPOTIFY_AUTHORIZE_URL = "https://accounts.spotify.com/authorize";
+const SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token";
+const AUTH_STATE_KEY = "spotify-auth-state";
+const AUTH_VERIFIER_KEY = "spotify-auth-verifier";
+const AUTH_REDIRECT_URI_KEY = "spotify-auth-redirect-uri";
+const ACCESS_TOKEN_KEY = "spotify-access-token";
+
+const generateRandomString = (length) => {
+  const alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const values = window.crypto.getRandomValues(new Uint8Array(length));
+
+  return Array.from(values, (value) => alphabet[value % alphabet.length]).join(
+    "",
+  );
+};
+
+const base64UrlEncode = (value) => {
+  const encoded = btoa(String.fromCharCode(...new Uint8Array(value)));
+  return encoded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+};
+
+const createCodeChallenge = async (codeVerifier) => {
+  const digest = await window.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(codeVerifier),
+  );
+  return base64UrlEncode(digest);
+};
+
+const parseHashItems = (hashValue) =>
+  hashValue
+    .substr(1)
+    .split("&")
+    .reduce((acc, element) => {
+      if (!element) {
+        return acc;
+      }
+
+      const [key, ...rest] = element.split("=");
+      acc[key] = rest.join("=");
+      return acc;
+    }, {});
+
+export const getRedirectUri = () =>
+  `${window.location.origin}${window.location.pathname}`;
+
+export const buildSpotifyAuthUrl = ({
+  clientId,
+  redirectUri,
+  scopes,
+  state,
+  codeChallenge,
+}) => {
+  const params = [
+    `response_type=code`,
+    `client_id=${encodeURIComponent(clientId)}`,
+    `redirect_uri=${encodeURIComponent(redirectUri)}`,
+    `scope=${encodeURIComponent(scopes.join(" "))}`,
+    `state=${encodeURIComponent(state)}`,
+    `code_challenge=${encodeURIComponent(codeChallenge)}`,
+    "code_challenge_method=S256",
+  ];
+
+  return `${SPOTIFY_AUTHORIZE_URL}?${params.join("&")}`;
+};
+
+export const calculateAuthentication = async () => {
+  const authentication = { code: null, accessToken: null, message: "" };
 
   const urlSearchParams = new URLSearchParams(window.location.search);
   const params = Object.fromEntries(urlSearchParams.entries());
@@ -16,34 +84,112 @@ export const calculateAuthentication = () => {
   if (params.hasOwnProperty("error")) {
     authentication.code = -1;
     authentication.message = params.error;
-  } else if (!window.location.hash) {
-    authentication.code = 0;
-    authentication.message = "Missing hash in the url";
-  } else {
-    const hashItems = window.location.hash
-      .substr(1)
-      .split("&")
-      .reduce((acc, element) => {
-        const parts = element.split("=");
-        acc[parts[0]] = parts[1];
-        return acc;
-      }, {});
-    if (hashItems.hasOwnProperty("access_token")) {
-      authentication.code = 1;
-      authentication.hashItems = hashItems;
-    } else {
-      authentication.code = -1;
-      authentication.message = "Hash does not include access_token";
+    return authentication;
+  }
+
+  const storedAccessToken = sessionStorage.getItem(ACCESS_TOKEN_KEY);
+  if (storedAccessToken) {
+    authentication.code = 1;
+    authentication.accessToken = storedAccessToken;
+    return authentication;
+  }
+
+  const authCode = params.code;
+  if (!authCode) {
+    if (window.location.hash) {
+      const hashItems = parseHashItems(window.location.hash);
+      if (hashItems.access_token) {
+        authentication.code = 1;
+        authentication.accessToken = hashItems.access_token;
+        sessionStorage.setItem(ACCESS_TOKEN_KEY, hashItems.access_token);
+        return authentication;
+      }
     }
+
+    authentication.code = 0;
+    authentication.message = "Missing authorization code in the url";
+    return authentication;
+  }
+
+  const state = params.state;
+  const expectedState = sessionStorage.getItem(AUTH_STATE_KEY);
+  const codeVerifier = sessionStorage.getItem(AUTH_VERIFIER_KEY);
+  const redirectUri =
+    sessionStorage.getItem(AUTH_REDIRECT_URI_KEY) || getRedirectUri();
+
+  if (!expectedState || !codeVerifier || state !== expectedState) {
+    authentication.code = -1;
+    authentication.message = "Unable to verify Spotify login request";
+    return authentication;
+  }
+
+  try {
+    const tokenResponse = await fetch(SPOTIFY_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: SPOTIFY_CLIENT_ID,
+        grant_type: "authorization_code",
+        code: authCode,
+        redirect_uri: redirectUri,
+        code_verifier: codeVerifier,
+      }),
+    });
+
+    const tokenBody = await tokenResponse.json();
+
+    if (!tokenResponse.ok) {
+      throw new Error(
+        tokenBody.error_description ||
+          tokenBody.error ||
+          "Unable to complete Spotify login",
+      );
+    }
+
+    if (!tokenBody.access_token) {
+      throw new Error("Spotify did not return an access token");
+    }
+
+    sessionStorage.setItem(ACCESS_TOKEN_KEY, tokenBody.access_token);
+    if (tokenBody.refresh_token) {
+      sessionStorage.setItem("spotify-refresh-token", tokenBody.refresh_token);
+    }
+
+    sessionStorage.removeItem(AUTH_STATE_KEY);
+    sessionStorage.removeItem(AUTH_VERIFIER_KEY);
+    sessionStorage.removeItem(AUTH_REDIRECT_URI_KEY);
+    window.history.replaceState({}, document.title, window.location.pathname);
+
+    authentication.code = 1;
+    authentication.accessToken = tokenBody.access_token;
+  } catch (error) {
+    authentication.code = -1;
+    authentication.message =
+      error.message || "Unable to complete Spotify login";
   }
 
   return authentication;
 };
 
-export const requestAuth = () => {
-  const redirectUri = encodeURIComponent(window.location.href);
-  const scopes = scopesList.join("%20");
-  window.location.href = `https://accounts.spotify.com/authorize?client_id=125aeb2f61c242c68fe33802c481bb08&redirect_uri=${redirectUri}&scope=${scopes}&response_type=token&state=202102121300`;
+export const requestAuth = async () => {
+  const redirectUri = getRedirectUri();
+  const state = generateRandomString(16);
+  const codeVerifier = generateRandomString(64);
+  const codeChallenge = await createCodeChallenge(codeVerifier);
+
+  sessionStorage.setItem(AUTH_STATE_KEY, state);
+  sessionStorage.setItem(AUTH_VERIFIER_KEY, codeVerifier);
+  sessionStorage.setItem(AUTH_REDIRECT_URI_KEY, redirectUri);
+
+  window.location.href = buildSpotifyAuthUrl({
+    clientId: SPOTIFY_CLIENT_ID,
+    redirectUri,
+    scopes: scopesList,
+    state,
+    codeChallenge,
+  });
 };
 
 export const getButtonIdsForUser = (userEmail) => {
@@ -61,7 +207,7 @@ export const getButtonIdsForUser = (userEmail) => {
             BUTTON_IDS.CANDLES,
             BUTTON_IDS.WBAB,
             BUTTON_IDS.SHARK,
-          ].includes(id)
+          ].includes(id),
       );
   }
 };
@@ -71,7 +217,7 @@ export const makeRequest = (
   method = "GET",
   access_token,
   fields = {},
-  queryParams = ""
+  queryParams = "",
 ) =>
   fetch(
     `https://api.spotify.com/v1/${path}${
@@ -79,7 +225,7 @@ export const makeRequest = (
       Object.keys(queryParams).reduce(
         (acc, element, index) =>
           `${acc}${index === 0 ? "?" : "&"}${element}=${queryParams[element]}`,
-        ""
+        "",
       )
     }`,
     {
@@ -90,7 +236,7 @@ export const makeRequest = (
         Authorization: `Bearer ${access_token}`,
       },
       ...fields,
-    }
+    },
   );
 
 export const getButtonOnClick =

--- a/src/Utils.test.js
+++ b/src/Utils.test.js
@@ -1,0 +1,21 @@
+import { buildSpotifyAuthUrl } from "./Utils";
+
+describe("Spotify auth URL generation", () => {
+  it("uses the authorization code flow with PKCE parameters", () => {
+    const url = buildSpotifyAuthUrl({
+      clientId: "test-client-id",
+      redirectUri: "https://example.com/callback",
+      scopes: ["user-read-private", "user-read-email"],
+      state: "test-state",
+      codeChallenge: "test-code-challenge",
+    });
+
+    expect(url).toContain("response_type=code");
+    expect(url).toContain("client_id=test-client-id");
+    expect(url).toContain("redirect_uri=https%3A%2F%2Fexample.com%2Fcallback");
+    expect(url).toContain("scope=user-read-private%20user-read-email");
+    expect(url).toContain("state=test-state");
+    expect(url).toContain("code_challenge=test-code-challenge");
+    expect(url).toContain("code_challenge_method=S256");
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/DanTheManGude/gude-tunes/issues/7

> Spotify login flow refactored
> The app now uses Spotify’s authorization code flow with PKCE instead of the old implicit token flow that was causing the “response_type must be code” error.
> 
> What changed
> [Utils.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): builds the Spotify authorize URL with [response_type=code](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), adds PKCE parameters, and exchanges the callback code for an access token.
> [App.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): initializes authentication on load and uses the exchanged token for the Spotify user/profile request.
> [Utils.test.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): adds a regression test for the new auth URL generation.
> 